### PR TITLE
Upgrade fast-jwt

### DIFF
--- a/packages/sst/package.json
+++ b/packages/sst/package.json
@@ -80,7 +80,7 @@
     "dotenv": "^16.0.3",
     "esbuild": "0.18.13",
     "express": "^4.18.2",
-    "fast-jwt": "^1.6.1",
+    "fast-jwt": "^3.1.1",
     "get-port": "^6.1.2",
     "glob": "^8.0.3",
     "graphql": "*",


### PR DESCRIPTION
SST fails to install on node 20.5.0 due to outdated package  `error fast-jwt@1.7.2: The engine "node" is incompatible with this module. Expected version ">=14 <20". Got "20.5.0"`